### PR TITLE
Remove unused function

### DIFF
--- a/hexwalk/edittagdialog.cpp
+++ b/hexwalk/edittagdialog.cpp
@@ -18,11 +18,6 @@ EditTagDialog::~EditTagDialog()
     delete ui;
 }
 
-void EditTagDialog::on_pushButton_clicked()
-{ 
-    this->hide();
-}
-
 void EditTagDialog::colorGen()
 {
     QRandomGenerator prng(time(0));

--- a/hexwalk/edittagdialog.h
+++ b/hexwalk/edittagdialog.h
@@ -20,8 +20,6 @@ public:
     BytePattern * bytePattern;
 
 private slots:
-    void on_pushButton_clicked();
-
     void on_colorButton_clicked();
 
     void on_applyButton_clicked();


### PR DESCRIPTION
This would generate a qt warning when starting the application:
`QMetaObject::connectSlotsByName: No matching signal for on_pushButton_clicked()`