### PR TITLE
Support Invert Matching

### DIFF
--- a/hexwalk/advancedsearchdialog.cpp
+++ b/hexwalk/advancedsearchdialog.cpp
@@ -52,7 +52,7 @@ qint64 AdvancedSearchDialog::findNext()
         if (ui->cbBackwards->isChecked())
             idx = _hexEdit->lastIndexOf(_findBa, from);
         else
-            idx = _hexEdit->indexOf(_findBa, from,ui->cbRegex->isChecked(),ui->cbCase->isChecked());
+            idx = _hexEdit->indexOf(_findBa, from,ui->cbRegex->isChecked(),ui->cbCase->isChecked(), ui->cbInvertMatch->isChecked());
     }
     return idx;
 }
@@ -299,7 +299,7 @@ void AdvancedSearchDialog::on_resultsTableView_clicked(const QModelIndex &index)
 {
     //_hexEdit->indexOf("",resultslist.at(index.row()).cursor,ui->cbRegex->isChecked(),ui->cbCase->isChecked(),ui->cbFindFormat->currentIndex()==1);
     _hexEdit->setCursorPosition(resultslist.at(index.row()).cursor);
-    _hexEdit->indexOf(_findBa, resultslist.at(index.row()).cursor - 1,ui->cbRegex->isChecked(),ui->cbCase->isChecked());
+    _hexEdit->indexOf(_findBa, resultslist.at(index.row()).cursor - 1,ui->cbRegex->isChecked(),ui->cbCase->isChecked(), ui->cbInvertMatch->isChecked());
     _hexEdit->update();
 
 }
@@ -328,6 +328,19 @@ void AdvancedSearchDialog::on_cbCase_clicked()
 
 }
 
+void AdvancedSearchDialog::on_cbInvertMatch_clicked()
+{
+    if(ui->cbInvertMatch->isChecked())
+    {
+        ui->cbBackwards->setChecked(false);
+        ui->cbBackwards->setEnabled(false);
+    }
+    else
+    {
+        ui->cbBackwards->setChecked(false);
+        ui->cbBackwards->setEnabled(true);
+    }
+}
 
 void AdvancedSearchDialog::on_cbFindFormat_currentIndexChanged(int index)
 {
@@ -351,10 +364,25 @@ void AdvancedSearchDialog::on_cbBackwards_clicked()
     if(ui->cbBackwards->isChecked())
     {
         ui->cbRegex->setChecked(false);
+        ui->cbRegex->setEnabled(false);
         ui->cbCase->setChecked(false);
+        ui->cbCase->setEnabled(false);
+        ui->cbInvertMatch->setChecked(false);
+        ui->cbInvertMatch->setEnabled(false);
         ui->cbBegin->setChecked(false);
+        ui->cbBegin->setEnabled(false);
     }
-
+    else
+    {
+        ui->cbRegex->setChecked(false);
+        ui->cbRegex->setEnabled(true);
+        ui->cbCase->setChecked(false);
+        ui->cbCase->setEnabled(true);
+        ui->cbInvertMatch->setChecked(false);
+        ui->cbInvertMatch->setEnabled(true);
+        ui->cbBegin->setChecked(false);
+        ui->cbBegin->setEnabled(true);
+    }
 }
 
 

--- a/hexwalk/advancedsearchdialog.h
+++ b/hexwalk/advancedsearchdialog.h
@@ -82,7 +82,7 @@ void on_pbFindAll_clicked();
     void on_pbCancel_clicked();
 
 void on_cbCase_clicked();
-
+    void on_cbInvertMatch_clicked();
     void on_cbFindFormat_currentIndexChanged(int index);
 
 void on_cbBackwards_clicked();

--- a/hexwalk/advancedsearchdialog.ui
+++ b/hexwalk/advancedsearchdialog.ui
@@ -94,6 +94,13 @@
           </property>
          </widget>
         </item>
+        <item row="2" column="1">
+         <widget class="QCheckBox" name="cbInvertMatch">
+          <property name="text">
+           <string>Invert Match</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>

--- a/qhexedit/chunks.cpp
+++ b/qhexedit/chunks.cpp
@@ -167,8 +167,7 @@ bool Chunks::dataChanged(qint64 pos)
 
 
 // ***************************************** Search API
-
-qint64 Chunks::indexOf(const QByteArray &ba, qint64 from,bool isRegex,bool isCaseInsensitive)
+qint64 Chunks::indexOf(const QByteArray &ba, qint64 from,bool isRegex,bool isCaseInsensitive,bool invertMatch)
 {
     qint64 result = -1;
     QByteArray buffer;
@@ -204,8 +203,30 @@ qint64 Chunks::indexOf(const QByteArray &ba, qint64 from,bool isRegex,bool isCas
             matchSize = ba.size();
         }
 
-        if (findPos >= 0)
-            result = pos + (qint64)findPos;
+        // If invertMatch is true, we want to find the first position that does not match.
+        if (invertMatch) {
+            if (findPos < 0) {
+                // If we found a non-match at the beginning, set the result and break.
+                result = pos;
+            }
+            else if (findPos == 0) {
+                // If we found a match at the beginning, continue searching for non-match byte
+                // by byte.
+                pos += 1;
+                pos -= BUFFER_SIZE;
+            } else {
+                // If we found a match after some bytes, so before that number of bytes
+                // was a non-match.
+                result = pos;
+                matchSize = findPos;
+            }
+        } else {
+            // Normal matching logic.
+            if (findPos >= 0) {
+                result = pos + (qint64)findPos;
+            }
+        }
+
     }
     return result;
 }

--- a/qhexedit/chunks.h
+++ b/qhexedit/chunks.h
@@ -44,7 +44,7 @@ public:
     bool dataChanged(qint64 pos);
 
     // Search API
-    qint64 indexOf(const QByteArray &ba, qint64 from,bool isRegex,bool isCaseInsensitive);
+    qint64 indexOf(const QByteArray &ba, qint64 from,bool isRegex,bool isCaseInsensitive, bool invertMatch = false);
     qint64 lastIndexOf(const QByteArray &ba, qint64 from);
 
     // Char manipulations

--- a/qhexedit/qhexedit.cpp
+++ b/qhexedit/qhexedit.cpp
@@ -444,10 +444,9 @@ void QHexEdit::ensureVisible()
     viewport()->update();
 }
 
-qint64 QHexEdit::indexOf(const QByteArray &ba, qint64 from, bool isRegex,bool isCaseInsensitive)
+qint64 QHexEdit::indexOf(const QByteArray &ba, qint64 from, bool isRegex,bool isCaseInsensitive, bool invertMatch)
 {
-    qint64 pos = _chunks->indexOf(ba, from,isRegex,isCaseInsensitive);
-    if (pos > -1)
+    qint64 pos = _chunks->indexOf(ba, from,isRegex,isCaseInsensitive, invertMatch);    if (pos > -1)
     {
         qint64 curPos = pos*2;
         setCursorPosition(curPos + _chunks->matchSize*2);

--- a/qhexedit/qhexedit.h
+++ b/qhexedit/qhexedit.h
@@ -250,9 +250,10 @@ public:
      * \param from Point where the search starts
      * \param isRegex regex on off switch
      * \param isCaseSensitive case sensitive on off switch
+     * \param invertMatch If true, checks for a non-match, instead of the default (check for a match).
      * \return pos if found, else -1
      */
-    qint64 indexOf(const QByteArray &ba, qint64 from, bool isRegex, bool isCaseSensitive);
+    qint64 indexOf(const QByteArray &ba, qint64 from, bool isRegex, bool isCaseSensitive, bool invertMatch = false);
 
     /*! Returns if any changes where done on document
      * \return true when document is modified else false


### PR DESCRIPTION
I have added a new search mode in the 'Advanced Search Dialog' called 'Invert Match'.
This feature allows users to search, for example, the first non-zero byte, among other functionalities.

<img width="1542" height="787" alt="invert_match_ss" src="https://github.com/user-attachments/assets/4cf1a911-4c73-48a0-81d1-e2f77a04f6a6" />
